### PR TITLE
Remove final from serialize and unserialize

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -143,7 +143,7 @@ abstract class Enum implements Serializable, JsonSerializable
      * @return string|void
      * @throws Throwable
      */
-    final public function serialize()
+    public function serialize()
     {
         throw self::createNoSerializeUnserializeException();
     }
@@ -153,7 +153,7 @@ abstract class Enum implements Serializable, JsonSerializable
      *
      * @throws Throwable
      */
-    final public function unserialize($serialized)
+    public function unserialize($serialized)
     {
         throw self::createNoSerializeUnserializeException();
     }


### PR DESCRIPTION
Remove final to ovewrite these methods on my class because I want to store Enum instances on Memcache.